### PR TITLE
feat: send artifact url via webhooks

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -63,11 +63,11 @@ jobs:
         with:
           name: app-debug.apk
           path: android/app/build/outputs/apk/
-
+      
       - name: Send Discord Webhook Message
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: "Android Build Completed\n\nCommit: ${{ github.event.head_commit.url }}\nBranch: ${{ github.event.repository.html_url }}/tree/${{ github.event.ref }}\n\nDownload APK: ${{ steps.artifact.outputs.download_url }}"
+          args: "Android Build Completed\n\nCommit: <${{ github.event.head_commit.url }}>\n\n[Download APK](<https://nightly.link/${{ github.repository_owner }}/${{ github.repository }}/workflows/android-build/main/app-debug.apk.zip>)"
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: "Android Build"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -65,7 +65,7 @@ jobs:
           path: android/app/build/outputs/apk/
 
       - name: Send Discord Webhook Message
-        uses: Ilshidur/action-discord@v3
+        uses: Ilshidur/action-discord@master
         with:
           args: "Android Build Completed"
         env:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -58,7 +58,17 @@ jobs:
           cd android && ./gradlew assembleDebug --profile
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        id: artifact
+        uses: actions/upload-artifact@v2
         with:
           name: app-debug.apk
           path: android/app/build/outputs/apk/
+
+      - name: Send Discord Webhook Message
+        uses: appleboy/discord-action@master
+        with:
+          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          color: "#FF0000"
+          message: "New Android build is ready to download"
+          file: ${{ steps.artifact.outputs.download_url }}

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -65,11 +65,9 @@ jobs:
           path: android/app/build/outputs/apk/
 
       - name: Send Discord Webhook Message
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@0.3.2
         with:
-          args: "Android Build Completed"
+          args: "Android Build Completed\n\nCommit: ${{ github.sha }}\nBranch: ${{ github.ref }}\nTime: ${{ steps.time.outputs.time }}\n\n[Download APK](${{ steps.artifact.outputs.download_url }})]}"
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: "Android Build"
-          DISCORD_CONTENT: "Android Build Completed\n\nCommit: ${{ github.sha }}\nBranch: ${{ github.ref }}\nTime: ${{ steps.time.outputs.time }}"
-          DISCORD_FILE: ${{ steps.artifact.outputs.download_url }}

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Send Discord Webhook Message
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: "Android Build Completed\n\nCommit: <${{ github.event.head_commit.url }}>\n\n[Download APK](<https://nightly.link/${{ github.repository_owner }}/${{ github.repository }}/workflows/android-build/main/app-debug.apk.zip>)"
+          args: "Android Build Completed\n\nCommit: <${{ github.event.head_commit.url }}>\n\n[Download APK](<https://nightly.link/${{ github.repository }}/workflows/android-build/main/app-debug.apk.zip>)"
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: "Android Build"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -65,10 +65,11 @@ jobs:
           path: android/app/build/outputs/apk/
 
       - name: Send Discord Webhook Message
-        uses: appleboy/discord-action@master
+        uses: Ilshidur/action-discord@v3
         with:
-          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
-          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          color: "#FF0000"
-          message: "New Android build is ready to download"
-          file: ${{ steps.artifact.outputs.download_url }}
+          args: "Android Build Completed"
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: "Android Build"
+          DISCORD_CONTENT: "Android Build Completed\n\nCommit: ${{ github.sha }}\nBranch: ${{ github.ref }}\nTime: ${{ steps.time.outputs.time }}"
+          DISCORD_FILE: ${{ steps.artifact.outputs.download_url }}

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Send Discord Webhook Message
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: "Android Build Completed\n\nCommit: ${{ github.sha }}\nBranch: ${{ github.ref }}\nTime: ${{ steps.time.outputs.time }}\n\n[Download APK](${{ steps.artifact.outputs.download_url }})]}"
+          args: "Android Build Completed\n\nCommit: ${{ github.event.head_commit.url }}\nBranch: ${{ github.event.repository.html_url }}/tree/${{ github.event.ref }}\n\nDownload APK: ${{ steps.artifact.outputs.download_url }}"
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: "Android Build"


### PR DESCRIPTION
actually getting the artifact is a little annoying so we can just go ahead and send the download url via webhook
reuires webhook url as DISCORD_WEBHOOK secret