### PR TITLE
feat: semantic release workflow

### DIFF
--- a/.github/workflows/publish-semantic-release.yml
+++ b/.github/workflows/publish-semantic-release.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: Install Dependencies
+        run: yarn install
+        
+      - name: Publish Semantic Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release": "yarn version",
     "preversion": "yarn lint && yarn expover && git add app.json",
     "expover": "node -e \"let fs = require('fs'); let app = require('./app.json'); app.expo.version = require('./package.json').version; app.expo.android.versionCode = parseInt(app.expo.android.versionCode) + 1; fs.writeFileSync('./app.json', JSON.stringify(app, null, 2));\"",
-    "postversion": "git push && git push --tags && semantic-release --no-ci"
+    "postversion": "git push && git push --tags"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
this pr moves the semantic-release process into a workflows that runs whenever a new tag is pushed (yarn release), which will then create a semantic changelog and publish a github release, which will subsequently trigger the workflow which produces the eas build.

this requires a PAT to be set in the action secrets as `GITHUB_TOKEN`