### PR TITLE
chore: more workflow sheesh

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -62,4 +62,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: app-release.apk
-          path: android/app/build/outputs/apk/release/
+          path: /home/runner/work/Imageing/Imageing/build-*.apk

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   android-build:
+    if: ${{ secrets.EXPO_TOKEN }}
     name: Android Build
     runs-on: ubuntu-latest # using ubuntu latest version / or you can use a specific version
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - name: Check out Git repository # clone the repo to local ci workspace
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: yarn
@@ -59,7 +59,7 @@ jobs:
         run: eas build --platform android --profile preview --local
 
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: app-release.apk
           path: android/app/build/outputs/apk/release/

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -25,10 +25,10 @@ jobs:
           BASE_URL: https://exampleapp.com    
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: yarn
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "${{ steps.yarn-cache-path.outputs.dir }}"
           key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: EAS build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: "${{ runner.os }}-yarn-"
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --frozen-lockfile
 
       - name: Publish build
         run: eas build --platform android --profile preview 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: 18.x
           cache: yarn
 
-      - name: Install Node Modules
-        run: yarn install
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Run Lint
         run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Find yarn cache location
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: JS package cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-yarn-
         
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: yarn

--- a/.github/workflows/publish-semantic-release.yml
+++ b/.github/workflows/publish-semantic-release.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           node-version: 18.x
 
-      - name: Install Dependencies
-        run: yarn install
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
         
       - name: Publish Semantic Release
         env:

--- a/.github/workflows/publish-semantic-release.yml
+++ b/.github/workflows/publish-semantic-release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.x
 
       - name: Install Dependencies
         run: yarn install

--- a/eas.json
+++ b/eas.json
@@ -3,18 +3,22 @@
     "version": ">= 0.55.1"
   },
   "build": {
+	"production": {
+		"node": "18.13.0"
+	  },
     "development": {
+	  "extends": "production",
       "developmentClient": true,
       "distribution": "internal"
     },
     "preview": {
+	  "extends": "production",
       "distribution": "internal",
 	  "android": {
         "buildType": "apk"
       },
       "credentialsSource": "remote"
-    },
-    "production": {}
+    }
   },
   "submit": {
     "production": {}


### PR DESCRIPTION
- configures eas to always use node 18 lts
- only run release if publish succeeded, just to be super safe
- most likely use the correct path to upload build artifact
- always install with frozen lockfile
- bump used actions to latest version