### PR TITLE
fix: pr build workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,7 +2,7 @@ name: Android Build ## name of the workflow
 on: 
   push: # trigger the workflow on push event
     branches: [ main ] # trigger the workflow on push to main branch
-  pull_request: # trigger the workflow on pull request event
+  pull_request_target: # trigger the workflow on pull request target event
     branches: [ main ] # trigger the workflow on pull request to main branch
 
 jobs:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -5,7 +5,7 @@ on:
     types: [completed]
 jobs:
   pr_comment:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'pull_request_target' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
this pr fixes build workflows on pr's by using the pull_request_target event instead of the pull_request event which does not give the workflow access to the base repo secrets