### PR TITLE
feat: proper release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -2,7 +2,7 @@ name: Android Release
 on:
   workflow_dispatch: # To trigger manual build
   workflow_run:
-    workflows: ["Publish GitHub Release"]
+    workflows: ["Publish Semantic Release"]
     types:
       - completed
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -3,6 +3,7 @@ on:
   workflow_run:
     workflows: ['Android Build']
     types: [completed]
+
 jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/publish-semantic-release.yml
+++ b/.github/workflows/publish-semantic-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish:
-    name: Publish GitHub Release
+    name: Publish Semantic Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         
-      - name: Publish Semantic Release
+      - name: Run Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/publish-semantic-release.yml
+++ b/.github/workflows/publish-semantic-release.yml
@@ -1,14 +1,17 @@
-name: Publish GitHub Release
+name: Publish Semantic Release
 on:
  push:
   branches:
     - main
   paths-ignore:
     - '**.md'
+    - '**.json'
+    - '**.lock'
+    - '**.yml'
+    - '**.yaml'
 
 jobs:
   publish:
-    if: contains(github.event.head_commit.message, 'chore(release)')
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upload-release-apk.yml
+++ b/.github/workflows/upload-release-apk.yml
@@ -1,0 +1,58 @@
+on:
+  workflow_run:
+    workflows: ["Publish Semantic Release"]
+    types: [completed]
+
+jobs:
+  upload-release-apk:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository # clone the repo to local ci workspace
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: Set up our JDK environment # setup JDK environment: mandatory as we need to build android project
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 17
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore node_modules from cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Setup Expo
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Build Android APK
+        run: eas build --platform android --profile preview --local --non-interactive
+
+      - name: Upload APK to latest release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: /home/runner/work/Imageing/Imageing/build-*.apk
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.event.workflow_run.head_branch }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -28,6 +28,27 @@
 		{
 		  "successComment": false
 		}
+	  ],
+	  [
+		"semantic-release-expo",
+		{
+		  "releaseChannel": "default"
+		}
 	  ]
+	],
+	"verifyConditions": [
+	  "@semantic-release/git",
+	  "semantic-release-expo"
+	],
+	"prepare": [
+	  "semantic-release-expo",
+	  {
+		"path": "@semantic-release/git",
+		"assets": [
+			"package.json",
+			"yarn.lock",
+			"app.json"
+			]
+		}
 	]
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@react-navigation/material-top-tabs": "^6.5.2",
     "@react-navigation/native": "^6.0.11",
     "@react-navigation/stack": "^6.3.11",
+    "@semantic-release/git": "^10.0.1",
     "@types/react": "~18.0.24",
     "@types/react-native": "~0.70.6",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
@@ -74,7 +75,8 @@
     "react-native-simple-toast": "^2.0.0",
     "react-native-svg": "^13.7.0",
     "react-native-tab-view": "^3.3.4",
-    "react-native-web": "~0.18.9"
+    "react-native-web": "~0.18.9",
+    "semantic-release-expo": "^2.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "precommit": "lint-staged",
-    "prepare": "husky install",
-    "release": "yarn version",
-    "preversion": "yarn lint",
-    "expover": "node -e \"let fs = require('fs'); let app = require('./app.json'); app.expo.version = require('./package.json').version; app.expo.android.versionCode = parseInt(app.expo.android.versionCode) + 1; fs.writeFileSync('./app.json', JSON.stringify(app, null, 2));\"",
-    "postversion": "yarn expover && git add app.json && yarn push-release",
-    "push-release": "FOR /F \"usebackq\" %i IN (`node -e \"console.log(require('./package.json').version)\"`) DO git commit -m \"chore(release): v%i\" --allow-empty && git push"
+    "prepare": "husky install"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,20 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-3.0.0.tgz#30a3b97bbb5844d695eb22f9d3aa40f6a92770c2"
   integrity sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==
 
+"@semantic-release/git@^10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-10.0.1.tgz#c646e55d67fae623875bf3a06a634dd434904498"
+  integrity sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==
+  dependencies:
+    "@semantic-release/error" "^3.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    dir-glob "^3.0.0"
+    execa "^5.0.0"
+    lodash "^4.17.4"
+    micromatch "^4.0.0"
+    p-reduce "^2.0.0"
+
 "@semantic-release/github@^8.0.0":
   version "8.0.7"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-8.0.7.tgz#643aee7a5cdd2acd3ae643bb90ad4ac796901de6"
@@ -4337,6 +4351,16 @@ destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+detect-indent@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
+  integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
+
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 dezalgo@^1.0.0:
   version "1.0.4"
@@ -7759,7 +7783,7 @@ micromatch@^3.1.10:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -8729,6 +8753,11 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-reduce@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
+  integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
 
 p-reduce@^3.0.0:
   version "3.0.0"
@@ -9908,6 +9937,17 @@ scheduler@^0.22.0:
   integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
+
+semantic-release-expo@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/semantic-release-expo/-/semantic-release-expo-2.2.3.tgz#f7b7278c20084032406c3df4b0ee3b00825246e3"
+  integrity sha512-OjOtHY/Ay2tifB876T68L2xBzh676P4ZNLRKCnAxMd14t0comCQAVSUxbwF88tf1M0y+ndLOruhBeeop5FOG3A==
+  dependencies:
+    detect-indent "^6.0.0"
+    detect-newline "^3.0.0"
+    fs-extra "^8.1.0"
+    lodash "^4.17.15"
+    semver "^6.3.0"
 
 semantic-release@^20.1.0:
   version "20.1.0"


### PR DESCRIPTION
this pr attempts to both close #58 and to refactor the release pipeline.
Merging this will effectively designate the `main` branch as release branch.
This means that every commit to `main` that modifies source files (markup files are excluded) will trigger semantic release, which will fetch the latest tag and all commits that have occurred since then, and subsequently generate release notes, modify the expo manifest with incremented values and push a release commit alongside the github release.

Upon completion it will run a new workflow which will presumably build an apk and attach it to the previously published release