### PR TITLE
fix: save startup destination & reset dialog

### DIFF
--- a/src/screens/settings.tsx
+++ b/src/screens/settings.tsx
@@ -89,9 +89,13 @@ export default function SettingScreen({ navigation }) {
 		let isMounted = true;
 		if (isMounted) logLastModified(setLastModified);
 		getDestinationSettings()
-			.then(h => {
+			.then(async h => {
 				if (isMounted) {
-					setDestination(h);
+					setDestinationSettings(h.name)
+						.then(() => {
+							setDestination(h);
+						})
+						.catch(err => log.error(err));
 				}
 			})
 			.catch(err => log.error(err));
@@ -183,6 +187,14 @@ export default function SettingScreen({ navigation }) {
 				break;
 		}
 		setDialog(false);
+		// reset dialog
+		setDialogTitle('');
+		setDialogDescription('');
+		setRightDialogButton('');
+		setLeftDialogButton('');
+		setInputShow(false);
+		setInputValue('');
+		setDialogContext('');
 	};
 
 	const handleSwitch = async (h: DestinationNames) => {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,5 +1,5 @@
 export interface DestinationObject {
-	name: string;
+	name: DestinationNames;
 	url?: string;
 	settings?: {
 		apiKey?: string;


### PR DESCRIPTION
this pr closes #70, also letting the comment workflow finish before merge would be useful to see if it actually works now